### PR TITLE
Revise README for LARC OPEN 2026 project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-LARC 2026
+# LARC OPEN 2026
+
+Autonomous robot developed by RoBorregos for the IEEE Latin American Robotics Competition (LARC) 2026.
+
+---
+
+## Overview
+
+This repository contains the software architecture used for the autonomous robot, including:
+
+*  Omnidirectional drive control
+*  State Machine logic
+*  Elevator subsystem
+*  Sensor integration
+*  Vision communication
+*  Navigation and line following
+*  Competition-tested systems used during TMR
+
+---
+
+## Project Structure
+
+* `src/` → Main robot logic and state machine
+* `lib/` → Custom libraries and subsystems
+* `vision/` → Vision processing modules
+* `visao_rasp/` → Raspberry Pi / vision-side code
+* `include/` → Shared headers
+
+---
+
+## Technologies
+
+* C++
+* PlatformIO
+* Teensy 4.1
+* Python
+* OpenCV
+* YOLO
+
+---
+
+## Team
+
+* Ximena Patricia García — Programming (Control)
+* Maximo Fajardo — Programming (Vision/Sensors)
+* Hans Velarde — Mechanics
+* Erick Flores — Electronics
+
+---
+
+## 🏁 Competition
+Systems included in this repository were developed and tested during TMR for the LARC OPEN category.
+Systems included in this repository were developed and tested during TMR for the LARC OPEN category.
+


### PR DESCRIPTION
Updated the README to reflect project details for LARC OPEN 2026, including overview, project structure, technologies, and team members.